### PR TITLE
Fix reset password

### DIFF
--- a/app/endpoints/authentication/views.py
+++ b/app/endpoints/authentication/views.py
@@ -114,43 +114,47 @@ class Logout(MethodView):
 class ResetPassword(MethodView):
     @staticmethod
     def post():
-        email = request.form.get("email")
+        user_id, msg, status, status_code, _ = parse_auth_header(request)
+        if user_id is None:
+            return jsonify({
+                "status": status,
+                "message": msg
+            }), status_code
+
         password = request.form.get("password")
         confirm_password = request.form.get("confirm password")
-        if email and password and confirm_password:
-            if len(password) < 6:  # 6 is the minimum expected password length
+        if password and confirm_password:
+            if len(password) < 6:
                 return jsonify({
                     "status": "failure",
                     "message": "password must have a minimum of 6 characters"
                 }), 400
 
-            password_hash = Bcrypt().generate_password_hash(password).decode('utf-8')
-
-            # if the passwords are similar...
+            password_hash = Bcrypt().generate_password_hash(password).decode('utf8')
             if Bcrypt().check_password_hash(password_hash, confirm_password):
-                user = User.query.filter_by(email=email.lower()).first()
-                if user:
+                user = User.query.filter_by(id=user_id).first()
+                if user and not user.validate_password(password):
+                    # if old password is not similar to the new password
                     user.password = password_hash
                     user.save()
                     return jsonify({
                         "status": "success",
                         "message": f"password reset successful for '{user.email}'"
                     }), 200
-
                 return jsonify({
                     "status": "failure",
-                    "message": f"user with email `{email}` not found!"
-                }), 403
+                    "message": "Your new password should not be similar to "
+                    "your old password"
+                }), 400
+
             return jsonify({
                 "status": "failure",
                 "message": "the given passwords don't match"
             }), 403
-
         return jsonify({
             "status": "failure",
-            "message": "the fields: email, password, and 'confirm password' are required"
+            "message": "the fields 'password' and 'confirm password' are required"
         }), 400
-
 
 register_user = RegisterUser.as_view("register_user")
 login = Login.as_view("login")

--- a/app/endpoints/authentication/views.py
+++ b/app/endpoints/authentication/views.py
@@ -144,17 +144,18 @@ class ResetPassword(MethodView):
                 return jsonify({
                     "status": "failure",
                     "message": "Your new password should not be similar to "
-                    "your old password"
+                               "your old password"
                 }), 400
 
             return jsonify({
                 "status": "failure",
                 "message": "the given passwords don't match"
-            }), 403
+            }), 400
         return jsonify({
             "status": "failure",
             "message": "the fields 'password' and 'confirm password' are required"
         }), 400
+
 
 register_user = RegisterUser.as_view("register_user")
 login = Login.as_view("login")


### PR DESCRIPTION
#### What does this PR do?
This PR changes the signature of the `ResetPassword` API and makes it even more secure. 

#### Description of Task to be completed?
- Formerly, to reset a user's password, all it required was a user's `email`, the new `password` and the `confirm password` fields. It didn't even require an authentication token. 

- This made it so insecure in such a way that any person who knows the user's email can change/reset their password without their knowledge.

- To counter this, I modified the way the endpoint works. It now requires an authentication token which implies that you have to be logged in so as to reset your password.

- The endpoint takes as its input, the new `password` and the `confirm password` fields as its inputs.
 
- Using your old password as your new password is not allowed. It is assumed you are resetting the password probably due to a security threat against your account.

- The functionality remains the same but what changes is the way the problem is handled.

#### How should this be manually tested?
* This API is hosted on Heroku [here](shoppinglistapi1.herokuapp.com)
* Use [Postman](https://www.getpostman.com/) to test the API. 
* You need to first register a user, log them in and then reset the password.
* Check the `README.md` file for the respective endpoints to use

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A