### PR TITLE
Removes useless super Delegation 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,8 @@
 omit =]
     *docs*
     *migrations*
+    *virtualenv*
     */manage.py
     */test*.py
     */local_settings.py
+    */settings.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 
 # command to run tests
 script:
-  - nosetests -v --rednose --with-coverage --cover-package=.
+  - nosetests -v --rednose --with-coverage --cover-package=app
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 
 # command to run tests
 script:
-  - nosetests -v --rednose --with-coverage --cover-package=app
+  - nosetests -v --rednose --with-coverage --cover-package=.
 
 after_success:
   - coveralls

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ try:
     import settings
     TEST_DATABASE_URL = settings.TEST_DATABASE_URL
     DATABASE_URL = settings.DATABASE_URL
-except ImportError:
+except ImportError:  # pragma: no cover
     TEST_DATABASE_URL = os.getenv('TEST_DATABASE_URL')
     DATABASE_URL = os.getenv('DATABASE_URL')
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -3,9 +3,6 @@ from app.endpoints import parse_notify_date
 
 
 class TestEndpoints(BaseTests):
-    def setUp(self):
-        super(TestEndpoints, self).setUp()
-
     def test_parse_notify_date_fails_if_length_is_not_3(self):
         possible_cases = ["2017-02", "", "2018/02/12", "2018-09-8-3"]
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,9 +3,6 @@ from tests import BaseTests
 
 
 class TestErrors(BaseTests):
-    def setUp(self):
-        super(TestErrors, self).setUp()
-
     def test_405_errors_are_handled_gracefully(self):
         resp = self.test_client.get("/api/v1/auth/login")
         self.assertEqual(resp.status_code, 405)

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -3,9 +3,6 @@ from tests import BaseTests
 
 
 class TestItemsAPI(BaseTests):
-    def setUp(self):
-        super(TestItemsAPI, self).setUp()
-
     def test_post_item_is_successful_if_all_parameters_are_given(self):
         self.test_client.post(
             "/api/v1/auth/register", data=self.user_data)
@@ -406,9 +403,6 @@ class TestItemsAPI(BaseTests):
 
 
 class TestItemsAPIByID(BaseTests):
-    def setup(self):
-        super(TestItemsAPIByID, self).setUp()
-
     def test_get_item_by_id_is_successful_for_a_given_list_and_item_id(self):
         self.test_client.post("/api/v1/auth/register", data=self.user_data)
 

--- a/tests/test_shoppinglist.py
+++ b/tests/test_shoppinglist.py
@@ -489,9 +489,6 @@ class TestShoppingListAPI(BaseTests):
 
 
 class TestShoppingListByID(BaseTests):
-    def setUp(self):
-        super(TestShoppingListByID, self).setUp()
-
     def test_get_shopping_list_by_id_is_successful(self):
         self.test_client.post("/api/v1/auth/register", data=self.user_data)
 


### PR DESCRIPTION
#### What does this PR do?
Removes redundant `setUp()` initializer methods in the tests for both `shoppinglists` and `items`